### PR TITLE
fix: softfail if rmSync fails

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -23,7 +23,12 @@ export const createStore = (write, extension = '') => {
     },
     dispose: async () => {
       if (temp) {
-        fs.rmSync(temp, { recursive: true, force: true })
+        try {
+          fs.rmSync(temp, { recursive: true, force: true })
+        }
+        catch {
+          // softfail if rmdir fails
+        }
       }
     }
   }


### PR DESCRIPTION
allow rmSync() to softfail on windows

fixes `barnard59 cube check-observations` for streamed cubes on windows

nb: current sitation fails with 
```
$ barnard59 cube check-observations --constraint constraint.ttl <  cube.ttl | barnard59 shacl report-summary

Error: ENOTEMPTY: directory not empty, rmdir 'C:\Users\Rdataflow\AppData\Local\Temp\2\external-merge-sort\U6p75f'
    at Object.rmdirSync (node:fs:1219:11)
    at _rmdirSync (node:internal/fs/rimraf:260:21)
    at rimrafSync (node:internal/fs/rimraf:193:7)
    at Object.rmSync (node:fs:1268:10)
    at Duplexify.dispose (file:///C:/temp/cube-link/node_modules/external-merge-sort/storage.js:28:12)
    at Duplexify.emit (node:events:530:35)
    at finish (node:internal/streams/writable:945:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4051,
  code: 'ENOTEMPTY',
  syscall: 'rmdir',
  path: 'C:\\Users\\Rdataflow\\AppData\\Local\\Temp\\2\\external-merge-sort\\U6p75f'
}
```